### PR TITLE
Fix Update messages with repeated city name

### DIFF
--- a/script.js
+++ b/script.js
@@ -211,7 +211,7 @@ Update.prototype.update = function() {
   }
   this.button.innerHTML = format(cost);
   this.button.disabled = cost > this.city.currency;
-  this.label.innerHTML = message.replace('CITY', '<b>' + this.city.name + '</b>');
+  this.label.innerHTML = message.replace(/CITY/g, '<b>' + this.city.name + '</b>');
 };
 
 var City = function(data) {


### PR DESCRIPTION
The `CITY` placeholder was only replaced once in each string, but some strings, such as 'Upgrade CITY Mall to CITY Megamall', have `CITY` twice; this resulted in 'Upgrade The City Mall to CITY Megamall':

![Screenshot_2020-03-03 CityClicker](https://user-images.githubusercontent.com/15960782/75815984-a0a60800-5d94-11ea-85aa-452a2f6861db.png)
